### PR TITLE
Make ortografia-cacera operational without `<dialog>` API

### DIFF
--- a/ortografia-cacera.html
+++ b/ortografia-cacera.html
@@ -1,0 +1,480 @@
+<!DOCTYPE html>
+<html lang="ca">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Caça Ortogràfica Catalana</title>
+  <style>
+    :root {
+      color-scheme: dark;
+      --bg: #0f172a;
+      --panel: #1e293b;
+      --accent: #f59e0b;
+      --good: #22c55e;
+      --bad: #ef4444;
+      --text: #e2e8f0;
+    }
+
+    * { box-sizing: border-box; }
+
+    body {
+      margin: 0;
+      font-family: "Trebuchet MS", "Segoe UI", sans-serif;
+      background: radial-gradient(circle at top, #1e293b 0%, var(--bg) 45%);
+      color: var(--text);
+      min-height: 100vh;
+      display: grid;
+      place-items: center;
+      padding: 1rem;
+    }
+
+    .game-shell {
+      width: min(1080px, 100%);
+      background: #0b1120d9;
+      border: 2px solid #334155;
+      border-radius: 14px;
+      box-shadow: 0 20px 40px #00000080;
+      overflow: hidden;
+    }
+
+    .hud {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 0.75rem;
+      justify-content: space-between;
+      align-items: center;
+      background: var(--panel);
+      padding: 0.8rem 1rem;
+      border-bottom: 2px solid #334155;
+    }
+
+    .stats {
+      display: flex;
+      gap: 0.7rem;
+      font-weight: 700;
+      font-size: 1rem;
+      flex-wrap: wrap;
+    }
+
+    .tag { padding: 0.2rem 0.5rem; border-radius: 999px; }
+    .tag.good { background: #052e16; color: var(--good); border: 1px solid #14532d; }
+    .tag.bad { background: #3f1414; color: #fecaca; border: 1px solid #7f1d1d; }
+
+    .actions {
+      display: flex;
+      gap: 0.5rem;
+      align-items: center;
+      flex-wrap: wrap;
+    }
+
+    button {
+      border: none;
+      border-radius: 8px;
+      padding: 0.5rem 0.9rem;
+      font-weight: 700;
+      background: var(--accent);
+      color: #111827;
+      cursor: pointer;
+    }
+
+    button.secondary {
+      background: #93c5fd;
+      color: #0f172a;
+    }
+
+    button:hover { filter: brightness(1.08); }
+
+    #gameArea {
+      position: relative;
+      height: 560px;
+      overflow: hidden;
+      cursor: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='64' height='64' viewBox='0 0 64 64'%3E%3Cg transform='rotate(-24 30 32)'%3E%3Crect x='7' y='27' width='35' height='8' rx='3' fill='%23783420'/%3E%3Crect x='38' y='29' width='18' height='4' rx='2' fill='%23d1d5db'/%3E%3Crect x='15' y='35' width='8' height='16' rx='2' fill='%2392400e'/%3E%3Ccircle cx='56' cy='31' r='3' fill='%23fde047'/%3E%3C/g%3E%3C/svg%3E") 14 26, crosshair;
+      background-image:
+        linear-gradient(to top, #134e4a 0 15%, transparent 15%),
+        linear-gradient(to bottom, #1d4ed8a8 0%, #7dd3fca8 38%, #bfdbfe88 72%, #0f172a 100%),
+        url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='900' height='560' viewBox='0 0 900 560'%3E%3Cg fill='white' fill-opacity='0.35'%3E%3Cellipse cx='120' cy='92' rx='74' ry='28'/%3E%3Cellipse cx='180' cy='115' rx='96' ry='32'/%3E%3Cellipse cx='440' cy='84' rx='88' ry='30'/%3E%3Cellipse cx='640' cy='120' rx='120' ry='40'/%3E%3Cellipse cx='810' cy='94' rx='72' ry='24'/%3E%3C/g%3E%3C/svg%3E");
+      background-size: cover;
+      user-select: none;
+    }
+
+    .word {
+      position: absolute;
+      transform: translate(-50%, -50%);
+      padding: 0.25rem 0.55rem;
+      border-radius: 8px;
+      font-size: 1.15rem;
+      font-weight: 800;
+      text-shadow: 0 2px 2px #00000066;
+      white-space: nowrap;
+      pointer-events: none;
+      border: 2px solid;
+      animation: bob 1.1s ease-in-out infinite alternate;
+    }
+
+    .word.correct {
+      color: #bbf7d0;
+      background: #14532dbb;
+      border-color: #22c55e;
+    }
+
+    .word.incorrect {
+      color: #fecaca;
+      background: #7f1d1dbb;
+      border-color: #ef4444;
+    }
+
+    @keyframes bob {
+      from { margin-top: -2px; }
+      to { margin-top: 2px; }
+    }
+
+    .shot {
+      position: absolute;
+      width: 20px;
+      height: 20px;
+      transform: translate(-50%, -50%);
+      border: 2px solid #fef08a;
+      border-radius: 50%;
+      box-shadow: 0 0 12px #fde047;
+      pointer-events: none;
+      animation: pop 240ms ease-out forwards;
+    }
+
+    @keyframes pop {
+      from { opacity: 1; transform: translate(-50%, -50%) scale(0.35); }
+      to { opacity: 0; transform: translate(-50%, -50%) scale(1.4); }
+    }
+
+    .overlay {
+      position: absolute;
+      inset: 0;
+      display: grid;
+      place-items: center;
+      text-align: center;
+      padding: 1.5rem;
+      background: #020617cc;
+      backdrop-filter: blur(2px);
+      z-index: 5;
+    }
+
+    .overlay h2 { margin: 0; font-size: clamp(1.4rem, 2.3vw, 2rem); }
+    .overlay p { margin: 0.75rem 0 1rem; max-width: 42ch; }
+
+    .tip {
+      font-size: 0.92rem;
+      padding: 0.4rem 0.7rem;
+      background: #0f172acc;
+      border-top: 1px solid #334155;
+    }
+
+    .editor-panel {
+      border-top: 1px solid #334155;
+      background: #0b1224;
+      padding: 1rem;
+    }
+
+    .editor {
+      padding: 0;
+    }
+
+    .editor h3 {
+      margin-top: 0;
+      margin-bottom: 0.35rem;
+    }
+
+    .editor p {
+      margin-top: 0;
+      color: #bfdbfe;
+      font-size: 0.95rem;
+    }
+
+    .grid {
+      display: grid;
+      grid-template-columns: minmax(150px, 1fr) minmax(180px, 1fr);
+      gap: 0.4rem 0.8rem;
+      max-height: 330px;
+      overflow: auto;
+      padding-right: 0.2rem;
+      margin-bottom: 0.9rem;
+    }
+
+    .grid label {
+      display: contents;
+    }
+
+    .grid span {
+      background: #1e293b;
+      border-radius: 6px;
+      padding: 0.35rem 0.55rem;
+      border: 1px solid #334155;
+    }
+
+    .grid input {
+      border: 1px solid #475569;
+      border-radius: 6px;
+      background: #111827;
+      color: #e2e8f0;
+      padding: 0.35rem 0.5rem;
+      font-weight: 600;
+    }
+
+    .editor-actions {
+      display: flex;
+      justify-content: flex-end;
+      gap: 0.5rem;
+    }
+  </style>
+</head>
+<body>
+  <main class="game-shell" aria-label="Joc de caça ortogràfica">
+    <header class="hud">
+      <div class="stats">
+        <span class="tag good">Punts: <strong id="score">0</strong></span>
+        <span class="tag">Vides: <strong id="lives">5</strong></span>
+        <span class="tag bad">Errades escapades: <strong id="escaped">0</strong></span>
+      </div>
+      <div class="actions">
+        <button id="startBtn" type="button">Comença la cacera</button>
+        <button id="editWordsBtn" type="button" class="secondary">Edita paraules errònies</button>
+      </div>
+    </header>
+
+    <section id="gameArea" aria-live="polite">
+      <div class="overlay" id="overlay">
+        <div>
+          <h2>Caçador d'ortografia catalana</h2>
+          <p>Dispara només a les paraules <strong>mal escrites</strong>. Si dispares una paraula correcta, perds punts. Si una paraula incorrecta arriba al terra, perds una vida.</p>
+          <button id="overlayBtn" type="button">Jugar ara</button>
+        </div>
+      </div>
+    </section>
+    <div class="tip">Consell: fes clic ràpid com si fossis un caçador de guatlles. Pots personalitzar les formes incorrectes abans de jugar.</div>
+  </main>
+
+  <section id="editorPanel" class="editor-panel" hidden>
+    <form class="editor" id="editorForm">
+      <h3>Editor de paraules errònies</h3>
+      <p>Modifica la columna de la dreta. La columna esquerra (forma correcta) serveix de referència.</p>
+      <div class="grid" id="editorGrid"></div>
+      <div class="editor-actions">
+        <button type="button" id="cancelEditor" class="secondary">Tanca</button>
+        <button type="submit">Desa canvis</button>
+      </div>
+    </form>
+  </section>
+
+  <script>
+    const gameArea = document.getElementById('gameArea');
+    const scoreEl = document.getElementById('score');
+    const livesEl = document.getElementById('lives');
+    const escapedEl = document.getElementById('escaped');
+    const startBtn = document.getElementById('startBtn');
+    const overlay = document.getElementById('overlay');
+    const overlayBtn = document.getElementById('overlayBtn');
+    const editWordsBtn = document.getElementById('editWordsBtn');
+    const editorPanel = document.getElementById('editorPanel');
+    const editorGrid = document.getElementById('editorGrid');
+    const editorForm = document.getElementById('editorForm');
+    const cancelEditor = document.getElementById('cancelEditor');
+
+    const basePairs = [
+      ['caçador', 'casador'], ['llengua', 'yengua'], ['qüestió', 'cuestió'],
+      ['intel·ligent', 'inteligent'], ['església', 'iglésia'], ['hivern', 'ivern'],
+      ['xarxa', 'charxa'], ['metge', 'metje'], ['cotxe', 'coxe'],
+      ['veïna', 'veina'], ['pingüí', 'pinguí'], ['allò', 'alló'],
+      ['ràpid', 'rapid'], ['muntanya', 'muntaña'], ['feliç', 'felis'],
+      ['història', 'istòria'], ['col·legi', 'colegi'], ['qüestió', 'questió'],
+      ['escola', 'escolla'], ['joguina', 'jogina'], ['pluja', 'plutja'],
+      ['caixa', 'caxa'], ['vuit', 'buit'], ['anyell', 'anell']
+    ];
+
+    let lexicon = basePairs.map(([correct, wrong]) => [correct, wrong]);
+
+    let state = {
+      running: false,
+      score: 0,
+      lives: 5,
+      escaped: 0,
+      words: [],
+      spawnTimer: 0,
+      lastTime: 0,
+      speed: 55
+    };
+
+    function updateHud() {
+      scoreEl.textContent = state.score;
+      livesEl.textContent = state.lives;
+      escapedEl.textContent = state.escaped;
+    }
+
+    function resetGame() {
+      state = {
+        running: true,
+        score: 0,
+        lives: 5,
+        escaped: 0,
+        words: [],
+        spawnTimer: 0,
+        lastTime: performance.now(),
+        speed: 55
+      };
+      gameArea.querySelectorAll('.word').forEach(el => el.remove());
+      updateHud();
+      overlay.hidden = true;
+      requestAnimationFrame(loop);
+    }
+
+    function spawnWord() {
+      const [correct, wrong] = lexicon[Math.floor(Math.random() * lexicon.length)];
+      const isIncorrect = Math.random() < 0.45;
+      const text = isIncorrect ? wrong : correct;
+      const el = document.createElement('div');
+      el.className = `word ${isIncorrect ? 'incorrect' : 'correct'}`;
+      el.textContent = text;
+
+      const x = 60 + Math.random() * (gameArea.clientWidth - 120);
+      el.style.left = `${x}px`;
+      el.style.top = '-20px';
+      gameArea.appendChild(el);
+
+      state.words.push({
+        el,
+        x,
+        y: -20,
+        vy: state.speed + Math.random() * 42,
+        isIncorrect
+      });
+    }
+
+    function shoot(x, y) {
+      if (!state.running) return;
+
+      const shot = document.createElement('div');
+      shot.className = 'shot';
+      shot.style.left = `${x}px`;
+      shot.style.top = `${y}px`;
+      gameArea.appendChild(shot);
+      setTimeout(() => shot.remove(), 260);
+
+      let hit = false;
+      state.words = state.words.filter(w => {
+        const dx = w.x - x;
+        const dy = w.y - y;
+        const distance = Math.hypot(dx, dy);
+        const targetSize = Math.max(40, w.el.clientWidth / 2);
+
+        if (distance <= targetSize) {
+          hit = true;
+          if (w.isIncorrect) {
+            state.score += 10;
+          } else {
+            state.score = Math.max(0, state.score - 6);
+          }
+          w.el.remove();
+          return false;
+        }
+        return true;
+      });
+
+      if (!hit) state.score = Math.max(0, state.score - 1);
+      updateHud();
+    }
+
+    function endGame() {
+      state.running = false;
+      overlay.hidden = false;
+      overlay.innerHTML = `
+        <div>
+          <h2>Fi de la partida</h2>
+          <p>Has aconseguit <strong>${state.score} punts</strong>. Les paraules incorrectes que han escapat: ${state.escaped}.</p>
+          <button id="overlayRestart" type="button">Torna a jugar</button>
+        </div>`;
+      document.getElementById('overlayRestart').addEventListener('click', resetGame);
+    }
+
+    function loop(now) {
+      if (!state.running) return;
+      const dt = (now - state.lastTime) / 1000;
+      state.lastTime = now;
+      state.spawnTimer += dt;
+      state.speed += dt * 0.8;
+
+      if (state.spawnTimer >= 0.72) {
+        state.spawnTimer = 0;
+        spawnWord();
+      }
+
+      state.words = state.words.filter(w => {
+        w.y += w.vy * dt;
+        w.el.style.top = `${w.y}px`;
+
+        if (w.y > gameArea.clientHeight + 30) {
+          w.el.remove();
+          if (w.isIncorrect) {
+            state.lives -= 1;
+            state.escaped += 1;
+          } else {
+            state.score += 2;
+          }
+          return false;
+        }
+        return true;
+      });
+
+      updateHud();
+      if (state.lives <= 0) {
+        endGame();
+      } else {
+        requestAnimationFrame(loop);
+      }
+    }
+
+    function openEditor() {
+      editorGrid.innerHTML = '';
+      lexicon.forEach(([correct, wrong], index) => {
+        const label = document.createElement('label');
+
+        const ref = document.createElement('span');
+        ref.textContent = correct;
+
+        const input = document.createElement('input');
+        input.name = `wrong-${index}`;
+        input.value = wrong;
+        input.required = true;
+        input.maxLength = 30;
+
+        label.append(ref, input);
+        editorGrid.appendChild(label);
+      });
+
+      editorPanel.hidden = false;
+    }
+
+    function saveEditorChanges() {
+      const updated = lexicon.map(([correct], index) => {
+        const input = editorForm.elements.namedItem(`wrong-${index}`);
+        const raw = input && "value" in input ? input.value : "";
+        const value = String(raw).trim();
+        return [correct, value || basePairs[index][1]];
+      });
+
+      lexicon = updated;
+      editorPanel.hidden = true;
+    }
+
+    gameArea.addEventListener('click', (ev) => {
+      const rect = gameArea.getBoundingClientRect();
+      shoot(ev.clientX - rect.left, ev.clientY - rect.top);
+    });
+
+    startBtn.addEventListener('click', resetGame);
+    overlayBtn.addEventListener('click', resetGame);
+    editWordsBtn.addEventListener('click', openEditor);
+    cancelEditor.addEventListener('click', () => { editorPanel.hidden = true; });
+    editorForm.addEventListener('submit', (ev) => {
+      ev.preventDefault();
+      saveEditorChanges();
+    });
+  </script>
+</body>
+</html>


### PR DESCRIPTION
### Motivation
- The in-page editor previously relied on the `<dialog>` API (and `showModal()`/`close()`), which can be unsupported and cause script failure making the UI appear unclickable.
- Optional chaining and fragile access patterns when reading editor inputs can also trigger runtime errors in older JS engines and stop script execution.

### Description
- Replaced the modal `<dialog>` editor with an in-page collapsible `section` (`#editorPanel`) controlled via the `hidden` attribute and added a corresponding `.editor-panel` CSS rule.
- Reworked editor open/close flows to use `editorPanel.hidden = false` / `editorPanel.hidden = true` instead of `showModal()`/`close()` and updated the cancel button to hide the panel.
- Hardened input reading in `saveEditorChanges()` by avoiding optional chaining and using an explicit check `input && "value" in input ? input.value : ""` to produce stable string values.
- Left spawn/shoot/HUD/gameplay logic intact and preserved the `lexicon` cloning approach with `basePairs.map(...)` for broad compatibility.

### Testing
- Parsed the updated `ortografia-cacera.html` with Python `html.parser`, which completed successfully.
- Served the page with `python3 -m http.server` and ran a Playwright script that opened the editor, edited and saved a wrong word, started the game, clicked the game area, and verified a shot was created (`shots 1`) with no page errors (`errors 0`).
- Captured a screenshot artifact after the Playwright run and all automated checks passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698c3a492ed4832ba8c7d7f27024cc35)